### PR TITLE
Add basic APNS client debug logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ const EndpointManager = require("./lib/protocol/endpointManager")({
 });
 
 const Client = require("./lib/client")({
+  logger: debug,
   config,
   EndpointManager,
 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,6 +4,7 @@ const VError = require("verror");
 const extend = require("./util/extend");
 
 module.exports = function (dependencies) {
+  const logger          = dependencies.logger;
   const config          = dependencies.config;
   const EndpointManager = dependencies.EndpointManager;
 
@@ -72,6 +73,9 @@ module.exports = function (dependencies) {
 
       return new Promise ( resolve => {
         stream.on("end", () => {
+          if (logger.enabled) {
+            logger(`Request ended with status ${status} and responseData: ${responseData}`);
+          }
           if (status === "200") {
             resolve({ device });
           } else if (responseData !== "") {
@@ -102,8 +106,14 @@ module.exports = function (dependencies) {
         stream.on("error", err => {
           let error;
           if (typeof err === "string") {
+            if (logger.enabled) {
+              logger(`Request error: ${err}`);
+            }
             error = new VError("apn write failed: %s", err);
           } else {
+            if (logger.enabled) {
+              logger(`Request error: ${JSON.stringify(err)}`);
+            }
             error = new VError(err, "apn write failed");
           }
           resolve({ device, error });


### PR DESCRIPTION
Adds some debug logging to the APNS client. Corresponds roughly to https://github.com/parse-community/node-apn/commit/8ac2793c7dedbc35627870d9b8946b00573b5459 on the parse-community fork.

To view debug output, run the set the environment variable `DEBUG=apn` when running the service.  For details, see the [debug](https://www.npmjs.com/package/debug) package docs.