### PR TITLE
Add shutdown function to the mock

### DIFF
--- a/mock/client.js
+++ b/mock/client.js
@@ -9,5 +9,7 @@ module.exports = function() {
     return { device };
   };
 
+  Client.prototype.shutdown = function mockShutdown() {};
+
   return Client;
 };


### PR DESCRIPTION
This is needed to avoid the CI failure when testing a apn provider mock that uses the shutdown function, [see](https://gerrit.wikimedia.org/r/c/mediawiki/services/push-notifications/+/638172).